### PR TITLE
Raycaster.Map.destroy() doesn't work for Arcade and Matter bodies

### DIFF
--- a/src/map/destroy.js
+++ b/src/map/destroy.js
@@ -9,7 +9,7 @@
  export function destroy() {
     //destroy reference to map object in mapped object
     if(this.object.type === 'body' || this.object.type === 'composite') {
-        delete object.raycasterMap;
+        delete this.object.raycasterMap;
     }
     else if(this.object.data) {
         this.object.data.remove('raycasterMap');


### PR DESCRIPTION
Fixing the issue where the Raycaster.Map#destroy function doesn't work. https://github.com/wiserim/phaser-raycaster/issues/39

This PR

* Fixes a bug

Fixing https://github.com/wiserim/phaser-raycaster/issues/39 where the `Raycaster.Map#destroy` function doesn't work