### PR TITLE
fix: for tilemaps the bottom row was missed by the point generation l…

### DIFF
--- a/src/map/map-tilemap-methods.js
+++ b/src/map/map-tilemap-methods.js
@@ -156,7 +156,7 @@ export function updateMap() {
     startPoint = false;
     endPoint = false;
 
-    for(let i = 1, iLength = this.object.layer.data.length - 1; i < iLength; i++) {
+    for(let i = 1, iLength = this.object.layer.data.length - 1; i <= iLength; i++) {
         row = this.object.layer.data[i];
         let higherRow = this.object.layer.data[i - 1];
 

--- a/src/map/map-tilemap-methods.js
+++ b/src/map/map-tilemap-methods.js
@@ -156,7 +156,7 @@ export function updateMap() {
     startPoint = false;
     endPoint = false;
 
-    for(let i = 1, iLength = this.object.layer.data.length - 1; i <= iLength; i++) {
+    for(let i = 1, iLength = this.object.layer.data.length; i < iLength; i++) {
         row = this.object.layer.data[i];
         let higherRow = this.object.layer.data[i - 1];
 


### PR DESCRIPTION
With a specific tile map configuration (one that surrounds a map with ray caster mapped tiles - essentially creating a border that should intercept all rays before hitting the bounding box), the bottom points were being missed as this loop did not process the final row.

Before the patch:

![before_patch](https://github.com/user-attachments/assets/1aa5bf08-bd3a-43a8-97ef-ca43734f95d8)


After the patch:

![after_patch](https://github.com/user-attachments/assets/d83abea1-c462-4ae5-bea6-40b6295c4b2c)
